### PR TITLE
Add stable environment requirement for release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    environment: stable
     steps:
     - name: Checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4


### PR DESCRIPTION
Once the environment is configured, this will ensure that we need an approval from another team member before releasing.

Contributes to [AC-3632](https://warthogs.atlassian.net/browse/AC-3632)

[AC-3632]: https://warthogs.atlassian.net/browse/AC-3632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ