### PR TITLE
Add 7 days cooldown for renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,6 +7,9 @@
     ":ignoreUnstable",
     "group:allNonMajor"
   ],
+  "minimumReleaseAge": "7 days",
+  "minimumReleaseAgeBehaviour": "timestamp-optional",
+  "prCreation": "not-pending",
   "packageRules": [
     {
       "groupName": "GitHub actions",


### PR DESCRIPTION
Add 7 days cooldown to prevent some supply chain attacks.

Contributes to [AC-4433](https://warthogs.atlassian.net/browse/AC-4433)

[AC-4433]: https://warthogs.atlassian.net/browse/AC-4433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ